### PR TITLE
fix: remove DynamicResourceAllocation feature gate

### DIFF
--- a/kubernetes/upgrade/checks.go
+++ b/kubernetes/upgrade/checks.go
@@ -257,12 +257,11 @@ func NewChecks(path *Path, state state.State, k8sConfig *rest.Config, controlPla
 			// https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md
 			"1.32->1.33": {
 				removedFeatureGates: []string{
-					"AppArmor",                               // https://github.com/kubernetes/kubernetes/pull/129375
-					"AppArmorFields",                         // https://github.com/kubernetes/kubernetes/pull/129497
-					"CPUManager",                             // https://github.com/kubernetes/kubernetes/pull/129296
-					"DisableCloudProviders",                  // https://github.com/kubernetes/kubernetes/pull/130162
-					"DisableKubeletCloudCredentialProviders", // https://github.com/kubernetes/kubernetes/pull/130162
-					"DynamicResourceAllocation",
+					"AppArmor",                                // https://github.com/kubernetes/kubernetes/pull/129375
+					"AppArmorFields",                          // https://github.com/kubernetes/kubernetes/pull/129497
+					"CPUManager",                              // https://github.com/kubernetes/kubernetes/pull/129296
+					"DisableCloudProviders",                   // https://github.com/kubernetes/kubernetes/pull/130162
+					"DisableKubeletCloudCredentialProviders",  // https://github.com/kubernetes/kubernetes/pull/130162
 					"JobPodFailurePolicy",                     // https://github.com/kubernetes/kubernetes/pull/129498
 					"KubeProxyDrainingTerminatingNodes",       // https://github.com/kubernetes/kubernetes/pull/129692
 					"PDBUnhealthyPodEvictionPolicy",           // https://github.com/kubernetes/kubernetes/pull/129500


### PR DESCRIPTION
It is still present in Kubernetes:

https://github.com/kubernetes/kubernetes/blob/60a317eadfcb839692a68eab88b2096f4d708f4f/pkg/features/kube_features.go#L263-L264

See https://github.com/siderolabs/talos/issues/10979