### PR TITLE
feat: add StateProvider for per-node COSI state in upgrade checks

### DIFF
--- a/kubernetes/upgrade/checks.go
+++ b/kubernetes/upgrade/checks.go
@@ -26,9 +26,16 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+// StateProvider returns a COSI state client for a specific node.
+// This allows callers to provide per-node state clients instead of relying on client.WithNode() proxying.
+//
+// The caller is responsible for managing the lifecycle of the returned state clients (e.g. closing connections).
+type StateProvider func(ctx context.Context, node string) (state.State, error)
+
 // Checks is a set of checks to run before upgrading k8s components.
 type Checks struct { //nolint:govet
 	state             state.State
+	stateProvider     StateProvider
 	k8sConfig         *rest.Config
 	controlPlaneNodes []string
 	workerNodes       []string
@@ -79,10 +86,26 @@ type componentCheck struct {
 	removedFlags []string
 }
 
-// NewChecks initializes and returns Checks.
-func NewChecks(path *Path, state state.State, k8sConfig *rest.Config, controlPlaneNodes, workerNodes []string, logFunc func(string, ...any)) (*Checks, error) {
+// NewChecks initializes and returns Checks that use client.WithNode() to route per-node COSI queries.
+func NewChecks(path *Path, st state.State, k8sConfig *rest.Config, controlPlaneNodes, workerNodes []string, logFunc func(string, ...any)) (*Checks, error) {
+	checks := newChecks(path, k8sConfig, controlPlaneNodes, workerNodes, logFunc)
+	checks.state = st
+
+	return checks, nil
+}
+
+// NewChecksWithStateProvider initializes and returns Checks that use the given provider to obtain per-node COSI state clients.
+//
+// The caller is responsible for managing the lifecycle of the returned state clients (e.g. closing connections).
+func NewChecksWithStateProvider(path *Path, provider StateProvider, k8sConfig *rest.Config, controlPlaneNodes, workerNodes []string, logFunc func(string, ...any)) (*Checks, error) {
+	checks := newChecks(path, k8sConfig, controlPlaneNodes, workerNodes, logFunc)
+	checks.stateProvider = provider
+
+	return checks, nil
+}
+
+func newChecks(path *Path, k8sConfig *rest.Config, controlPlaneNodes, workerNodes []string, logFunc func(string, ...any)) *Checks {
 	return &Checks{
-		state:             state,
 		k8sConfig:         k8sConfig,
 		log:               logFunc,
 		upgradePath:       path.String(),
@@ -311,7 +334,20 @@ func NewChecks(path *Path, state state.State, k8sConfig *rest.Config, controlPla
 				},
 			},
 		},
-	}, nil
+	}
+}
+
+// nodeState returns the context and state to use for querying a specific node's COSI resources.
+// When a StateProvider is set, it is used to get a per-node state client.
+// Otherwise, client.WithNode() is used to route through the shared state client.
+func (checks *Checks) nodeState(ctx context.Context, node string) (context.Context, state.State, error) {
+	if checks.stateProvider != nil {
+		st, err := checks.stateProvider(ctx, node)
+
+		return ctx, st, err
+	}
+
+	return client.WithNode(ctx, node), checks.state, nil
 }
 
 // Run executes the checks.
@@ -324,8 +360,13 @@ func (checks *Checks) Run(ctx context.Context) error {
 		checks.log("checking for removed Kubernetes component flags")
 
 		for _, node := range checks.controlPlaneNodes {
+			nodeCtx, nodeState, err := checks.nodeState(ctx, node)
+			if err != nil {
+				return err
+			}
+
 			for _, id := range []string{k8s.APIServerID, k8s.ControllerManagerID, k8s.SchedulerID} {
-				staticPod, err := safe.StateGet[*k8s.StaticPod](client.WithNode(ctx, node), checks.state, k8s.NewStaticPod(k8s.NamespaceName, id).Metadata())
+				staticPod, err := safe.StateGet[*k8s.StaticPod](nodeCtx, nodeState, k8s.NewStaticPod(k8s.NamespaceName, id).Metadata())
 				if err != nil {
 					if state.IsNotFoundError(err) {
 						continue
@@ -354,7 +395,12 @@ func (checks *Checks) Run(ctx context.Context) error {
 		}
 
 		for _, node := range append(append([]string(nil), checks.controlPlaneNodes...), checks.workerNodes...) {
-			kubeletSpec, err := safe.StateGet[*k8s.KubeletSpec](client.WithNode(ctx, node), checks.state, k8s.NewKubeletSpec(k8s.NamespaceName, k8s.KubeletID).Metadata())
+			nodeCtx, nodeState, err := checks.nodeState(ctx, node)
+			if err != nil {
+				return err
+			}
+
+			kubeletSpec, err := safe.StateGet[*k8s.KubeletSpec](nodeCtx, nodeState, k8s.NewKubeletSpec(k8s.NamespaceName, k8s.KubeletID).Metadata())
 			if err != nil {
 				if state.IsNotFoundError(err) {
 					continue

--- a/kubernetes/upgrade/checks_test.go
+++ b/kubernetes/upgrade/checks_test.go
@@ -307,3 +307,82 @@ func TestK8sComponentRemovedItemsWithKubeletError(t *testing.T) {
 
 	assert.Equal(t, expected, removedItemsError)
 }
+
+func TestK8sComponentRemovedItemsWithStateProvider(t *testing.T) {
+	ctx, ctxCancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	defer ctxCancel()
+
+	// Create separate per-node states to prove the provider dispatches correctly.
+	// node-1 has a removed flag; node-2 does not.
+	nodeStates := map[string]state.State{
+		"node-1": state.WrapCore(namespaced.NewState(inmem.Build)),
+		"node-2": state.WrapCore(namespaced.NewState(inmem.Build)),
+	}
+
+	// node-1: kube-apiserver with a removed flag (service-account-api-audiences, removed in 1.24→1.25)
+	for _, id := range []string{k8s.APIServerID, k8s.ControllerManagerID, k8s.SchedulerID} {
+		cfg := k8s.NewStaticPod(k8s.NamespaceName, id)
+
+		command := []string{"/usr/local/bin/" + id}
+		if id == k8s.APIServerID {
+			command = append(command, "--service-account-api-audiences=api")
+		}
+
+		cfg.TypedSpec().Pod = map[string]any{
+			"spec": map[string]any{
+				"containers": []any{
+					map[string]any{"command": command},
+				},
+			},
+		}
+
+		require.NoError(t, nodeStates["node-1"].Create(ctx, cfg))
+	}
+
+	// node-2: all clean, no removed flags
+	for _, id := range []string{k8s.APIServerID, k8s.ControllerManagerID, k8s.SchedulerID} {
+		cfg := k8s.NewStaticPod(k8s.NamespaceName, id)
+		cfg.TypedSpec().Pod = map[string]any{
+			"spec": map[string]any{
+				"containers": []any{
+					map[string]any{"command": []string{"/usr/local/bin/" + id}},
+				},
+			},
+		}
+
+		require.NoError(t, nodeStates["node-2"].Create(ctx, cfg))
+	}
+
+	path, err := upgrade.NewPath("1.24.3", "1.25.0")
+	require.NoError(t, err)
+
+	checks, err := upgrade.NewChecksWithStateProvider(path, func(_ context.Context, node string) (state.State, error) {
+		st, ok := nodeStates[node]
+		if !ok {
+			return nil, errors.New("unknown node: " + node)
+		}
+
+		return st, nil
+	}, nil, []string{"node-1", "node-2"}, nil, t.Logf)
+	require.NoError(t, err)
+
+	checkErrors := checks.Run(ctx)
+
+	var removedItemsError upgrade.ComponentRemovedItemsError
+	if !errors.As(checkErrors, &removedItemsError) {
+		t.Fatal("expected ComponentRemovedItemsError")
+	}
+
+	// Only node-1 should appear — node-2 has no removed flags.
+	expected := upgrade.ComponentRemovedItemsError{
+		CLIFlags: []upgrade.ComponentItem{
+			{
+				Node:      "node-1",
+				Component: "kube-apiserver",
+				Value:     "service-account-api-audiences",
+			},
+		},
+	}
+
+	assert.Equal(t, expected, removedItemsError)
+}


### PR DESCRIPTION
Add an alternative constructor for upgrade checks that accepts a callback to provide per-node COSI state clients directly, instead of relying on Talos node-to-node proxying.