### PR TITLE
feat: handle CR defined alongside their CRD in the same apply

### DIFF
--- a/internal/integration/server_side_apply_test.go
+++ b/internal/integration/server_side_apply_test.go
@@ -19,6 +19,7 @@ import (
 	fluxssa "github.com/fluxcd/pkg/ssa"
 	"github.com/fluxcd/pkg/ssa/utils"
 	"github.com/siderolabs/gen/xslices"
+	"github.com/siderolabs/go-retry/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -46,6 +47,10 @@ var (
 	secretManifest string
 	//go:embed testdata/deployment_manifest.yml
 	deploymentManifest string
+	//go:embed testdata/widget_crd.yaml
+	widgetCRDManifest string
+	//go:embed testdata/widget.yaml
+	widgetManifest string
 )
 
 func getTestObjects(t *testing.T) (ns, cm, secret, deploy *unstructured.Unstructured) {
@@ -98,11 +103,14 @@ func TestServerSideApply(t *testing.T) {
 	// NOTE: these tests need to run in sequence in correct order
 
 	t.Run("clean up from previous runs", func(t *testing.T) {
-		err = manager.Destroy(t.Context(), ssa.DestroyOptions{DeletePropagationPolicy: metav1.DeletePropagationForeground})
+		ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+		defer cancel()
+
+		err = manager.Destroy(ctx, ssa.DestroyOptions{DeletePropagationPolicy: metav1.DeletePropagationForeground})
 		require.NoError(t, err)
 
 		t.Log("wait until the namespace from previous run has fully terminated")
-		waitForResourceDeleted(t, dynamicClient, ns, mapper)
+		waitForResourceDeleted(ctx, t, dynamicClient, ns, mapper)
 	})
 
 	t.Run("deploy Namespace and ConfigMap", func(t *testing.T) {
@@ -223,7 +231,7 @@ func TestServerSideApply(t *testing.T) {
 			}
 		}
 
-		waitForResourceDeleted(t, dynamicClient, cm, mapper)
+		waitForResourceDeleted(t.Context(), t, dynamicClient, cm, mapper)
 	})
 
 	t.Run("inventory policy: unowned objects cannot be adopted with 'MustMatch' policy", func(t *testing.T) {
@@ -270,6 +278,104 @@ func TestServerSideApply(t *testing.T) {
 	})
 }
 
+func TestCRDWithCustomResourceApply(t *testing.T) {
+	kubeconfig := getKubeconfig(t)
+
+	dynamicClient, err := dynamic.NewForConfig(kubeconfig)
+	require.NoError(t, err)
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(kubeconfig)
+	require.NoError(t, err)
+
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(discoveryClient))
+
+	inventoryNS := "test-crd-inventory"
+	inventoryName := "test-crd-inventory"
+	manager, err := ssa.NewManager(t.Context(), kubeconfig, "crd-test-field-manager", inventoryNS, inventoryName)
+	require.NoError(t, err)
+
+	crd, err := utils.ReadObject(strings.NewReader(widgetCRDManifest))
+	require.NoError(t, err)
+
+	widget, err := utils.ReadObject(strings.NewReader(widgetManifest))
+	require.NoError(t, err)
+
+	ns, _, _, _ := getTestObjects(t)
+
+	if !skipCleanup {
+		t.Cleanup(func() {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+
+			require.NoError(t, manager.Destroy(cleanupCtx, ssa.DestroyOptions{DeletePropagationPolicy: metav1.DeletePropagationForeground}))
+
+			waitForResourceDeleted(cleanupCtx, t, dynamicClient, ns, mapper)
+			waitForResourceDeleted(cleanupCtx, t, dynamicClient, crd, mapper)
+		})
+	}
+
+	t.Run("clean up from previous runs", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+		defer cancel()
+
+		err = manager.Destroy(ctx, ssa.DestroyOptions{DeletePropagationPolicy: metav1.DeletePropagationForeground})
+		require.NoError(t, err)
+
+		waitForResourceDeleted(ctx, t, dynamicClient, ns, mapper)
+		waitForResourceDeleted(ctx, t, dynamicClient, crd, mapper)
+	})
+
+	t.Run("apply CRD and custom resource together", func(t *testing.T) {
+		var results []ssa.Change
+
+		err := retry.Constant(time.Second * 20).Retry(func() error {
+			var err error
+
+			results, err = manager.Apply(t.Context(), []*unstructured.Unstructured{ns, crd, widget}, ssa.ApplyOptions{})
+			if err != nil {
+				if !meta.IsNoMatchError(err) {
+					return err
+				}
+
+				mapper.Reset()
+
+				return retry.ExpectedError(err)
+			}
+
+			return nil
+		})
+		require.NoError(t, err, "failed to apply CRD and custom resource")
+		require.NotEmpty(t, results, "partial results for successfully applied objects should be returned")
+
+		resultsBySubject := map[string]ssa.Change{}
+		for _, r := range results {
+			resultsBySubject[r.Subject] = r
+		}
+
+		assert.Equal(t, ssa.CreatedAction, resultsBySubject["Widget/test-lab/my-shiny-widget"].Action)
+
+		assertResourceDeployed(t, dynamicClient, crd)
+		assertResourceDeployed(t, dynamicClient, widget)
+	})
+
+	t.Run("reapply CRD and custom resource, expect no changes", func(t *testing.T) {
+		// Re-read to get fresh objects without annotations from previous apply.
+		crd2, err := utils.ReadObject(strings.NewReader(widgetCRDManifest))
+		require.NoError(t, err)
+
+		widget2, err := utils.ReadObject(strings.NewReader(widgetManifest))
+		require.NoError(t, err)
+
+		results, err := manager.Apply(t.Context(), []*unstructured.Unstructured{ns, crd2, widget2}, ssa.ApplyOptions{})
+		require.NoError(t, err)
+		require.Len(t, results, 3)
+
+		for _, r := range results {
+			assert.Equal(t, ssa.UnchangedAction, r.Action, "expected unchanged for %s", r.Subject)
+		}
+	})
+}
+
 func assertResourceDeployed(t *testing.T, dynamicClient *dynamic.DynamicClient, obj *unstructured.Unstructured) *unstructured.Unstructured {
 	clusterObj, err := dynamicClient.Resource(
 		obj.GroupVersionKind().GroupVersion().WithResource(strings.ToLower(obj.GetKind())+"s"),
@@ -280,12 +386,18 @@ func assertResourceDeployed(t *testing.T, dynamicClient *dynamic.DynamicClient, 
 }
 
 // based on https://github.com/siderolabs/talos/blob/8b1c974a2a733c870f371ccb7a86ccc616dbc7ea/internal/integration/base/k8s.go#L876
-func waitForResourceDeleted(t *testing.T, dynamicClient *dynamic.DynamicClient, obj *unstructured.Unstructured, mapper meta.RESTMapper) {
+func waitForResourceDeleted(ctx context.Context, t *testing.T, dynamicClient *dynamic.DynamicClient, obj *unstructured.Unstructured, mapper meta.RESTMapper) {
 	t.Helper()
 
 	mapping, err := mapper.RESTMapping(obj.GetObjectKind().GroupVersionKind().GroupKind(), obj.GetObjectKind().GroupVersionKind().Version)
 	if err != nil {
-		assert.NoError(t, err, "error creating mapping for object %s", obj.GetName())
+		if meta.IsNoMatchError(err) {
+			t.Logf("resource type %s not found in RESTMapper, assuming crd wasn't applied", obj.GetKind())
+
+			return
+		}
+
+		require.NoError(t, err, "error creating mapping for object %s", obj.GetName())
 	}
 
 	dr := dynamicClient.Resource(mapping.Resource).Namespace(obj.GetNamespace())
@@ -295,12 +407,12 @@ func waitForResourceDeleted(t *testing.T, dynamicClient *dynamic.DynamicClient, 
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			options.FieldSelector = fieldSelector
 
-			return dr.List(t.Context(), options)
+			return dr.List(ctx, options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			options.FieldSelector = fieldSelector
 
-			return dr.Watch(t.Context(), options)
+			return dr.Watch(ctx, options)
 		},
 	}
 
@@ -320,7 +432,7 @@ func waitForResourceDeleted(t *testing.T, dynamicClient *dynamic.DynamicClient, 
 		return false, nil
 	}
 
-	watchCtx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	watchCtx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
 	_, err = watchtools.UntilWithSync(watchCtx, lw, &unstructured.Unstructured{}, preconditionFunc, func(event watch.Event) (bool, error) {

--- a/internal/integration/testdata/widget.yaml
+++ b/internal/integration/testdata/widget.yaml
@@ -1,0 +1,7 @@
+apiVersion: "stable.example.com/v1"
+kind: Widget
+metadata:
+  name: my-shiny-widget
+  namespace: test-lab
+spec:
+  color: "electric-blue"

--- a/internal/integration/testdata/widget_crd.yaml
+++ b/internal/integration/testdata/widget_crd.yaml
@@ -1,0 +1,26 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.stable.example.com
+spec:
+  group: stable.example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                color:
+                  type: string
+  scope: Namespaced
+  names:
+    plural: widgets
+    singular: widget
+    kind: Widget
+    shortNames:
+    - wd

--- a/kubernetes/ssa/apply.go
+++ b/kubernetes/ssa/apply.go
@@ -95,11 +95,11 @@ func (m *Manager) Apply(ctx context.Context, objects []*unstructured.Unstructure
 
 	inv, err := m.inventory(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get inventory, %w", err)
 	}
 
 	if err = m.prepareObjects(objects, inv.ID()); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to prepare objects for apply, %w", err)
 	}
 
 	setDefaultApplyOps(&ops)
@@ -107,10 +107,16 @@ func (m *Manager) Apply(ctx context.Context, objects []*unstructured.Unstructure
 	for _, obj := range objects {
 		_, diff, diffErr := m.diff(ctx, obj, ops.Force, ops.InventoryPolicy, inv.ID())
 		if diffErr != nil {
-			return nil, diffErr
+			return nil, fmt.Errorf("failed to diff object %s, %w", FormatObjectPathWithGV(obj), diffErr)
 		}
 
 		changeMap[FormatObjectPathWithGV(obj)].Diff = diff
+	}
+
+	// invalidate the RESTMapper cache to avoid potential "no matches for kind" errors during apply
+	// when CRDs are applied alongside their custom resources
+	if containsCRDs(objects) {
+		m.mapper.Reset()
 	}
 
 	changeSet, applyErr := m.resourceManager.ApplyAllStaged(ctx, objects, ssa.ApplyOptions{
@@ -119,7 +125,7 @@ func (m *Manager) Apply(ctx context.Context, objects []*unstructured.Unstructure
 		WaitTimeout:  ops.WaitTimeout,
 	})
 	if applyErr != nil && changeSet == nil {
-		return nil, applyErr
+		return nil, fmt.Errorf("apply failed: %w", applyErr)
 	}
 
 	inventoryObjRefs := inv.Get()
@@ -304,4 +310,15 @@ func changesMapToArray(changeMap map[string]*Change) []Change {
 	}
 
 	return changes
+}
+
+func containsCRDs(objects []*unstructured.Unstructured) bool {
+	for _, obj := range objects {
+		gvk := obj.GroupVersionKind()
+		if gvk.Group == "apiextensions.k8s.io" && gvk.Kind == "CustomResourceDefinition" {
+			return true
+		}
+	}
+
+	return false
 }

--- a/kubernetes/ssa/apply_test.go
+++ b/kubernetes/ssa/apply_test.go
@@ -7,6 +7,7 @@ package ssa_test
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"testing"
 
@@ -14,11 +15,22 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	sigsyaml "sigs.k8s.io/yaml"
 
 	"github.com/siderolabs/go-kubernetes/kubernetes/ssa"
 	"github.com/siderolabs/go-kubernetes/kubernetes/ssa/internal/inventory/memory"
 	"github.com/siderolabs/go-kubernetes/kubernetes/ssa/internal/resourcemanager"
 )
+
+type mapperMock struct{}
+
+func (m *mapperMock) Reset() {}
+
+//go:embed testdata/widget.yaml
+var widgetYAML []byte
+
+//go:embed testdata/widget_crd.yaml
+var widgetCRDYAML []byte
 
 func testInventoryClosure(_ context.Context, inv ssa.Inventory) ssa.InventoryFactory {
 	return func(context.Context) (ssa.Inventory, error) {
@@ -32,7 +44,7 @@ func testInventoryFactory(context.Context) (ssa.Inventory, error) {
 
 func TestCreateAllNew(t *testing.T) {
 	rm := resourcemanager.NewMock()
-	manager := ssa.NewCustomManager(rm, testInventoryFactory, nil)
+	manager := ssa.NewCustomManager(rm, testInventoryFactory, nil, &mapperMock{})
 	obj := getConfigmapManifest("test-cm")
 
 	results, err := manager.Apply(t.Context(), []*unstructured.Unstructured{obj}, ssa.ApplyOptions{})
@@ -62,7 +74,7 @@ func (m brokenApplyResourceManager) ApplyAllStaged(ctx context.Context, objects 
 func TestApplyError(t *testing.T) {
 	rm := &brokenApplyResourceManager{}
 	inv := memory.NewInventory("test-inventory")
-	manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil)
+	manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil, &mapperMock{})
 	obj1 := getConfigmapManifest("configmap1")
 	obj2 := getConfigmapManifest("configmap2")
 
@@ -79,7 +91,7 @@ func TestApplyError(t *testing.T) {
 func TestApplyError_No_Prune(t *testing.T) {
 	rm := &brokenApplyResourceManager{}
 	inv := memory.NewInventory("test-inventory")
-	manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil)
+	manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil, &mapperMock{})
 	obj1 := getConfigmapManifest("configmap1")
 	obj2 := getConfigmapManifest("configmap2")
 	existingObj := getConfigmapManifest("prune-configmap")
@@ -101,7 +113,7 @@ func TestApplyError_No_Prune(t *testing.T) {
 func TestResultDiff(t *testing.T) {
 	rm := resourcemanager.NewMock()
 	inv := memory.NewInventory("test-inventory")
-	manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil)
+	manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil, &mapperMock{})
 
 	existingObj := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -174,7 +186,7 @@ func TestInventoryErrors(t *testing.T) {
 			Inventory: *memory.NewInventory("test-inventory"),
 			writeErr:  writeErr,
 		}
-		manager := ssa.NewCustomManager(rm, func(ctx context.Context) (ssa.Inventory, error) { return inv, nil }, nil)
+		manager := ssa.NewCustomManager(rm, func(ctx context.Context) (ssa.Inventory, error) { return inv, nil }, nil, &mapperMock{})
 
 		obj := getConfigmapManifest("test-cm")
 
@@ -195,7 +207,7 @@ func TestInventoryErrors(t *testing.T) {
 			Inventory: *memory.NewInventory("test-inventory"),
 			writeErr:  writeErr,
 		}
-		manager := ssa.NewCustomManager(rm, func(ctx context.Context) (ssa.Inventory, error) { return inv, nil }, nil)
+		manager := ssa.NewCustomManager(rm, func(ctx context.Context) (ssa.Inventory, error) { return inv, nil }, nil, &mapperMock{})
 
 		pruneObj := getConfigmapManifest("should-not-be-pruned")
 		// Seed existing object directly into the resource manager since broken inventory can't Write.
@@ -216,7 +228,7 @@ func TestInventoryPolicy(t *testing.T) {
 		// The pre-apply check rejects objects that already carry a different inventory
 		// annotation, regardless of the inventory policy.
 		rm := resourcemanager.NewMock()
-		manager := ssa.NewCustomManager(rm, testInventoryFactory, nil)
+		manager := ssa.NewCustomManager(rm, testInventoryFactory, nil, &mapperMock{})
 
 		obj := getConfigmapManifest("test-cm")
 		obj.SetAnnotations(map[string]string{
@@ -233,7 +245,7 @@ func TestInventoryPolicy(t *testing.T) {
 	t.Run("policy_failure_prevents_all_applies", func(t *testing.T) {
 		// When one object fails the policy check, NO objects should be applied.
 		rm := resourcemanager.NewMock()
-		manager := ssa.NewCustomManager(rm, testInventoryFactory, nil)
+		manager := ssa.NewCustomManager(rm, testInventoryFactory, nil, &mapperMock{})
 
 		// This object exists in the cluster with a foreign annotation — will fail MustMatch.
 		foreignObj := getConfigmapManifest("foreign-cm")
@@ -258,7 +270,7 @@ func TestInventoryPolicy(t *testing.T) {
 	t.Run("policy_failure_prevents_pruning", func(t *testing.T) {
 		rm := resourcemanager.NewMock()
 		inv := memory.NewInventory("test-inventory")
-		manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil)
+		manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil, &mapperMock{})
 		pruneObj := getConfigmapManifest("prune-cm")
 		pruneObj.SetAnnotations(map[string]string{ssa.InventoryAnnotationKey: "foreign-inventory"})
 
@@ -305,7 +317,7 @@ func TestApplyEdgeCases(t *testing.T) {
 		// Re-applying the same objects should not duplicate inventory entries.
 		rm := resourcemanager.NewMock()
 		inv := memory.NewInventory("test-inventory")
-		manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil)
+		manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil, &mapperMock{})
 
 		obj := getConfigmapManifest("test-cm")
 
@@ -330,7 +342,7 @@ func TestApplyEdgeCases(t *testing.T) {
 	t.Run("diff_error", func(t *testing.T) {
 		// A non-NotFound error from Diff should abort Apply before any objects are applied.
 		rm := &brokenDiffResourceManager{}
-		manager := ssa.NewCustomManager(rm, testInventoryFactory, nil)
+		manager := ssa.NewCustomManager(rm, testInventoryFactory, nil, &mapperMock{})
 
 		obj := getConfigmapManifest("test-cm")
 
@@ -348,7 +360,7 @@ func TestApplyEdgeCases(t *testing.T) {
 		// When Delete fails during pruning, the error should be returned without the change result.
 		rm := &brokenDeleteResourceManager{}
 		inv := memory.NewInventory("test-inventory")
-		manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil)
+		manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil, &mapperMock{})
 
 		pruneObj := getConfigmapManifest("old-cm")
 		setExistingObjects(t, &rm.Mock, inv, pruneObj)
@@ -364,10 +376,40 @@ func TestApplyEdgeCases(t *testing.T) {
 		assert.Equal(t, "old-cm", invContents[0].Name)
 	})
 
+	t.Run("custom_resource_apply", func(t *testing.T) {
+		// CRDs and their custom resources should be applied successfully in the same Apply call, even though the CRD doesn't exist at the time of diff.
+		rm := resourcemanager.NewMock()
+		manager := ssa.NewCustomManager(rm, testInventoryFactory, nil, &mapperMock{})
+
+		crd := &unstructured.Unstructured{}
+		require.NoError(t, sigsyaml.Unmarshal(widgetCRDYAML, &crd.Object))
+
+		widget := &unstructured.Unstructured{}
+		require.NoError(t, sigsyaml.Unmarshal(widgetYAML, &widget.Object))
+
+		results, err := manager.Apply(t.Context(), []*unstructured.Unstructured{crd, widget}, ssa.ApplyOptions{})
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+
+		resultsBySubject := map[string]ssa.Change{}
+		for _, r := range results {
+			resultsBySubject[r.Subject] = r
+		}
+
+		assert.Equal(t, ssa.CreatedAction, resultsBySubject["CustomResourceDefinition/widgets.stable.example.com"].Action)
+		assert.Equal(t, ssa.CreatedAction, resultsBySubject["Widget/my-shiny-widget"].Action)
+
+		appliedCRD := rm.GetObject("apiextensions.k8s.io", "CustomResourceDefinition", "", "widgets.stable.example.com")
+		require.NotNil(t, appliedCRD)
+
+		appliedWidget := rm.GetObject("stable.example.com", "Widget", "", "my-shiny-widget")
+		require.NotNil(t, appliedWidget)
+	})
+
 	t.Run("no_prune_option", func(t *testing.T) {
 		rm := resourcemanager.NewMock()
 		inv := memory.NewInventory("test-inventory")
-		manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil)
+		manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil, &mapperMock{})
 
 		pruneObj := getConfigmapManifest("old-cm")
 		setExistingObjects(t, rm, inv, pruneObj)

--- a/kubernetes/ssa/destroy.go
+++ b/kubernetes/ssa/destroy.go
@@ -7,10 +7,12 @@ package ssa
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/fluxcd/pkg/ssa"
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -37,18 +39,26 @@ func (m *Manager) Destroy(ctx context.Context, ops DestroyOptions) error {
 
 	allInvObjects := inv.Get()
 
+	objects := make([]*unstructured.Unstructured, 0, len(allInvObjects))
+
 	for _, objMeta := range allInvObjects {
 		var obj *unstructured.Unstructured
 
 		obj, err = m.resourceManager.Get(ctx, objMeta)
 		if err != nil {
-			if apierrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
 				continue
 			}
 
 			return fmt.Errorf("failed to get object %s, %w", FormatMetaPath(objMeta), err)
 		}
 
+		objects = append(objects, obj)
+	}
+
+	sort.Sort(sort.Reverse(ssa.SortableUnstructureds(objects)))
+
+	for _, obj := range objects {
 		_, err = m.resourceManager.Delete(ctx, obj, ssa.DeleteOptions{PropagationPolicy: ops.DeletePropagationPolicy})
 		if err != nil {
 			return err

--- a/kubernetes/ssa/diff.go
+++ b/kubernetes/ssa/diff.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/siderolabs/talos/pkg/machinery/textdiff"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8syaml "sigs.k8s.io/yaml"
 )
@@ -80,7 +81,7 @@ func (m *Manager) Diff(ctx context.Context, objects []*unstructured.Unstructured
 		for _, objMeta := range pruneObjRefs {
 			obj, err := m.resourceManager.Get(ctx, objMeta)
 			if err != nil {
-				if apierrors.IsNotFound(err) {
+				if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
 					// object doesn't exist in the cluster so it can be skipped
 					continue
 				}
@@ -148,7 +149,7 @@ func (m *Manager) diff(
 	invID string,
 ) (*ssa.ChangeSetEntry, string, error) {
 	changeSet, inClusterObj, dryRunResult, err := m.resourceManager.Diff(ctx, inputObj, ssa.DiffOptions{Force: force})
-	if err != nil && (apierrors.IsNotFound(err) || strings.Contains(err.Error(), "not found")) {
+	if err != nil && (apierrors.IsNotFound(err) || meta.IsNoMatchError(err) || strings.Contains(err.Error(), "not found")) {
 		if changeSet == nil {
 			changeSet = &ssa.ChangeSetEntry{
 				ObjMetadata:  object.UnstructuredToObjMetadata(inputObj),

--- a/kubernetes/ssa/diff_test.go
+++ b/kubernetes/ssa/diff_test.go
@@ -29,7 +29,7 @@ func TestManager_Diff(t *testing.T) {
 
 	t.Run("CreateAction", func(t *testing.T) {
 		rm := resourcemanager.NewMock()
-		manager := ssa.NewCustomManager(rm, testInventoryFactory, nil)
+		manager := ssa.NewCustomManager(rm, testInventoryFactory, nil, &mapperMock{})
 
 		obj := &unstructured.Unstructured{
 			Object: map[string]any{
@@ -58,7 +58,7 @@ func TestManager_Diff(t *testing.T) {
 	t.Run("ModifyAction", func(t *testing.T) {
 		rm := resourcemanager.NewMock()
 		inv := memory.NewInventory("test-inventory")
-		manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil)
+		manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil, &mapperMock{})
 
 		existingObj := &unstructured.Unstructured{
 			Object: map[string]any{
@@ -99,7 +99,7 @@ func TestManager_Diff(t *testing.T) {
 	t.Run("Unchanged", func(t *testing.T) {
 		rm := resourcemanager.NewMock()
 		inv := memory.NewInventory("test-inventory")
-		manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil)
+		manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil, &mapperMock{})
 
 		obj := &unstructured.Unstructured{
 			Object: map[string]any{
@@ -134,7 +134,7 @@ func TestManager_Diff(t *testing.T) {
 	t.Run("PruneAction", func(t *testing.T) {
 		rm := resourcemanager.NewMock()
 		inv := memory.NewInventory("test-inventory")
-		manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil)
+		manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil, &mapperMock{})
 
 		// Object in inventory but not in applied objects
 		pruneObj := &unstructured.Unstructured{
@@ -167,7 +167,7 @@ func TestManager_Diff(t *testing.T) {
 	t.Run("NoPrune_option", func(t *testing.T) {
 		rm := resourcemanager.NewMock()
 		inv := memory.NewInventory("test-inventory")
-		manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil)
+		manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil, &mapperMock{})
 
 		pruneObj := &unstructured.Unstructured{
 			Object: map[string]any{
@@ -190,7 +190,7 @@ func TestManager_Diff(t *testing.T) {
 	t.Run("Diff_Render_Snapshot", func(t *testing.T) {
 		rm := resourcemanager.NewMock()
 		inv := memory.NewInventory("test-inventory")
-		manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil)
+		manager := ssa.NewCustomManager(rm, testInventoryClosure(t.Context(), inv), nil, &mapperMock{})
 
 		inputObject := &unstructured.Unstructured{
 			Object: map[string]any{

--- a/kubernetes/ssa/internal/resourcemanager/mock.go
+++ b/kubernetes/ssa/internal/resourcemanager/mock.go
@@ -13,6 +13,7 @@ import (
 	fluxssa "github.com/fluxcd/pkg/ssa"
 	"github.com/fluxcd/pkg/ssa/utils"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -28,8 +29,11 @@ type MockResourceManager interface {
 // Mock is an in-memory implementation of ssa.ResourceManager for unit tests.
 //
 // It simulates a Kubernetes cluster by storing objects in a map.
+// It tracks known GroupVersionKinds and rejects resources whose kind
+// is not registered (either as a built-in or via a CRD apply).
 type Mock struct {
-	objects map[objKey]*unstructured.Unstructured
+	objects   map[objKey]*unstructured.Unstructured
+	knownGVKs map[schema.GroupKind]bool
 }
 
 type objKey struct {
@@ -39,10 +43,89 @@ type objKey struct {
 	Name      string
 }
 
+// builtinGroupKinds are the core Kubernetes types that are always available.
+var builtinGroupKinds = []schema.GroupKind{
+	{Group: "", Kind: "ConfigMap"},
+	{Group: "", Kind: "Secret"},
+	{Group: "", Kind: "Service"},
+	{Group: "", Kind: "ServiceAccount"},
+	{Group: "", Kind: "Namespace"},
+	{Group: "", Kind: "Pod"},
+	{Group: "apps", Kind: "Deployment"},
+	{Group: "apps", Kind: "DaemonSet"},
+	{Group: "apps", Kind: "StatefulSet"},
+	{Group: "apps", Kind: "ReplicaSet"},
+	{Group: "batch", Kind: "Job"},
+	{Group: "batch", Kind: "CronJob"},
+	{Group: "rbac.authorization.k8s.io", Kind: "Role"},
+	{Group: "rbac.authorization.k8s.io", Kind: "RoleBinding"},
+	{Group: "rbac.authorization.k8s.io", Kind: "ClusterRole"},
+	{Group: "rbac.authorization.k8s.io", Kind: "ClusterRoleBinding"},
+	{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"},
+}
+
 // NewMock creates a new mock resource manager with an empty object store.
 func NewMock() *Mock {
+	known := make(map[schema.GroupKind]bool, len(builtinGroupKinds))
+	for _, gk := range builtinGroupKinds {
+		known[gk] = true
+	}
+
 	return &Mock{
-		objects: make(map[objKey]*unstructured.Unstructured),
+		objects:   make(map[objKey]*unstructured.Unstructured),
+		knownGVKs: known,
+	}
+}
+
+// checkKnownKind returns a NoKindMatchError if the object's GroupKind is not registered.
+// If knownGVKs is nil (e.g. when Mock is embedded without using NewMock), the check is skipped.
+func (m *Mock) checkKnownKind(obj *unstructured.Unstructured) error {
+	if m.knownGVKs == nil {
+		return nil
+	}
+
+	gvk := obj.GroupVersionKind()
+	gk := gvk.GroupKind()
+
+	if m.knownGVKs[gk] {
+		return nil
+	}
+
+	return &meta.NoKindMatchError{
+		GroupKind:        gk,
+		SearchedVersions: []string{gvk.Version},
+	}
+}
+
+// registerCRD extracts the custom resource GroupKind from a CRD object and registers it.
+func (m *Mock) registerCRD(obj *unstructured.Unstructured) {
+	gvk := obj.GroupVersionKind()
+	if gvk.Group != "apiextensions.k8s.io" || gvk.Kind != "CustomResourceDefinition" {
+		return
+	}
+
+	spec, ok := obj.Object["spec"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	group, ok := spec["group"].(string)
+	if !ok {
+		return
+	}
+
+	names, ok := spec["names"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	kind, ok := names["kind"].(string)
+	if !ok {
+		return
+	}
+
+	if group != "" && kind != "" {
+		m.knownGVKs[schema.GroupKind{Group: group, Kind: kind}] = true
 	}
 }
 
@@ -80,6 +163,10 @@ func (m *Mock) GetObject(group, kind, namespace, name string) *unstructured.Unst
 }
 
 func (m *Mock) Apply(_ context.Context, obj *unstructured.Unstructured, _ fluxssa.ApplyOptions) (*fluxssa.ChangeSetEntry, error) {
+	if err := m.checkKnownKind(obj); err != nil {
+		return nil, err
+	}
+
 	key := keyFromObj(obj)
 
 	action := fluxssa.CreatedAction
@@ -92,6 +179,8 @@ func (m *Mock) Apply(_ context.Context, obj *unstructured.Unstructured, _ fluxss
 	}
 
 	m.objects[key] = obj.DeepCopy()
+
+	m.registerCRD(obj)
 
 	return entryFromObj(obj, action), nil
 }
@@ -133,6 +222,10 @@ func (m *Mock) WaitForSetWithContext(ctx context.Context, set object.ObjMetadata
 func (m *Mock) Diff(_ context.Context, obj *unstructured.Unstructured, _ fluxssa.DiffOptions) (
 	*fluxssa.ChangeSetEntry, *unstructured.Unstructured, *unstructured.Unstructured, error,
 ) {
+	if err := m.checkKnownKind(obj); err != nil {
+		return nil, nil, nil, err
+	}
+
 	key := keyFromObj(obj)
 
 	existing, exists := m.objects[key]
@@ -166,7 +259,7 @@ func entryFromObj(obj *unstructured.Unstructured, action fluxssa.Action) *fluxss
 			Name:      obj.GetName(),
 			GroupKind: obj.GroupVersionKind().GroupKind(),
 		},
-		GroupVersion: obj.GetAPIVersion(),
+		GroupVersion: obj.GroupVersionKind().Version,
 		Subject:      utils.FmtUnstructured(obj),
 		Action:       action,
 	}

--- a/kubernetes/ssa/ssa.go
+++ b/kubernetes/ssa/ssa.go
@@ -37,11 +37,16 @@ type InventoryBackedManager interface {
 // InventoryFactory creates inventory objects.
 type InventoryFactory func(ctx context.Context) (Inventory, error)
 
+type restMapper interface {
+	Reset()
+}
+
 // Manager is the default Manager implementation.
 type Manager struct {
 	resourceManager  ResourceManager
 	inventoryFactory InventoryFactory
 	httpClient       *http.Client
+	mapper           restMapper
 }
 
 // inventory returns the inventory object for the manager.
@@ -65,11 +70,12 @@ type ResourceManager interface {
 }
 
 // NewCustomManager creates a new manager with specified resource manager and inventory.
-func NewCustomManager(resourceManager ResourceManager, inventoryFactory InventoryFactory, httpClient *http.Client) *Manager {
+func NewCustomManager(resourceManager ResourceManager, inventoryFactory InventoryFactory, httpClient *http.Client, mapper restMapper) *Manager {
 	return &Manager{
 		resourceManager:  resourceManager,
 		inventoryFactory: inventoryFactory,
 		httpClient:       httpClient,
+		mapper:           mapper,
 	}
 }
 
@@ -114,7 +120,7 @@ func NewManager(ctx context.Context, kubeconfig *rest.Config, fieldManagerName, 
 		mapper:     mapper,
 	}
 
-	return NewCustomManager(resourceManager, inventoryFactory, httpClient), nil
+	return NewCustomManager(resourceManager, inventoryFactory, httpClient, mapper), nil
 }
 
 // Close performs any necessary cleanup, such as closing the HTTP connections.

--- a/kubernetes/ssa/testdata/widget.yaml
+++ b/kubernetes/ssa/testdata/widget.yaml
@@ -1,0 +1,6 @@
+apiVersion: "stable.example.com/v1"
+kind: Widget
+metadata:
+  name: my-shiny-widget
+spec:
+  color: "electric-blue"

--- a/kubernetes/ssa/testdata/widget_crd.yaml
+++ b/kubernetes/ssa/testdata/widget_crd.yaml
@@ -1,0 +1,26 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.stable.example.com
+spec:
+  group: stable.example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                color:
+                  type: string
+  scope: Namespaced
+  names:
+    plural: widgets
+    singular: widget
+    kind: Widget
+    shortNames:
+    - wd


### PR DESCRIPTION
When a CRD and its custom resources are applied together, the diff phase would fail with NoKindMatchError for the CR since the CRD hasn't been applied yet. Treat NoKindMatchError as a "to be created" case so the apply can proceed.

Also make the mock resource manager CRD-aware: it now tracks known GroupKinds, returns NoKindMatchError for unknown kinds, and dynamically registers custom resource kinds when a CRD is applied.