### PR TITLE
fix: return the apply results in a consistent order

### DIFF
--- a/internal/integration/server_side_apply_test.go
+++ b/internal/integration/server_side_apply_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
@@ -124,14 +125,16 @@ func TestServerSideApply(t *testing.T) {
 		}
 
 		resultSubjects := xslices.Map(results, func(r ssa.Change) string { return r.Subject })
-		require.Contains(t, resultSubjects, "Namespace/test-lab")
-		require.Contains(t, resultSubjects, "ConfigMap/test-lab/app-config")
+		assert.Equal(t, []string{"Namespace/test-lab", "ConfigMap/test-lab/app-config"}, resultSubjects)
 	})
 
 	t.Run("deploy Namespace and ConfigMap a second time, expect no changes", func(t *testing.T) {
 		results, err := manager.Apply(t.Context(), []*unstructured.Unstructured{ns, cm}, ssa.ApplyOptions{})
 		require.NoError(t, err)
 		require.Len(t, results, 2)
+
+		resultSubjects := xslices.Map(results, func(r ssa.Change) string { return r.Subject })
+		assert.Equal(t, []string{"Namespace/test-lab", "ConfigMap/test-lab/app-config"}, resultSubjects)
 
 		for _, r := range results {
 			assert.Equal(t, ssa.UnchangedAction, r.Action)
@@ -140,12 +143,19 @@ func TestServerSideApply(t *testing.T) {
 	})
 
 	t.Run("add a Secret to the existing set", func(t *testing.T) {
-		results, err := manager.Apply(t.Context(), []*unstructured.Unstructured{ns, cm, secret}, ssa.ApplyOptions{})
+		results, err := manager.Apply(
+			t.Context(), []*unstructured.Unstructured{ns, cm, secret},
+			ssa.ApplyOptions{
+				CustomStageKinds: map[schema.GroupKind]struct{}{
+					// push secret to the custom stage, so it comes before the configmap
+					schema.ParseGroupKind("Secret"): {},
+				},
+			})
 		require.NoError(t, err)
 		require.Len(t, results, 3)
 
 		resultSubjects := xslices.Map(results, func(r ssa.Change) string { return r.Subject })
-		require.Contains(t, resultSubjects, "Secret/test-lab/app-secret")
+		assert.Equal(t, []string{"Namespace/test-lab", "Secret/test-lab/app-secret", "ConfigMap/test-lab/app-config"}, resultSubjects)
 
 		for _, r := range results {
 			if r.Subject == "Secret/test-lab/app-secret" {
@@ -197,6 +207,9 @@ func TestServerSideApply(t *testing.T) {
 		results, err := manager.Apply(t.Context(), []*unstructured.Unstructured{ns, cmModified, secretModified}, ssa.ApplyOptions{})
 		require.NoError(t, err)
 		require.Len(t, results, 3)
+
+		subjects := xslices.Map(results, func(r ssa.Change) string { return r.Subject })
+		assert.Equal(t, []string{"Namespace/test-lab", "ConfigMap/test-lab/app-config", "Secret/test-lab/app-secret"}, subjects)
 
 		for _, r := range results {
 			if r.Subject == "ConfigMap/test-lab/app-config" {

--- a/kubernetes/ssa/apply.go
+++ b/kubernetes/ssa/apply.go
@@ -18,6 +18,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/siderolabs/go-kubernetes/kubernetes"
 	"github.com/siderolabs/go-kubernetes/kubernetes/ssa/object"
@@ -25,6 +26,9 @@ import (
 
 // ApplyOptions defines the options for the Apply method.
 type ApplyOptions struct {
+	// CustomStageKinds defines a set of Kubernetes resource types that should be applied
+	// in a separate stage after CRDs and before namespaced objects.
+	CustomStageKinds map[schema.GroupKind]struct{}
 	// InventoryPolicy defines if an inventory object can take over objects that belong to another inventory object or don't belong to any inventory object.
 	InventoryPolicy InventoryPolicy
 	// DeletePropagationPolicy configures the delete operation propagation policy.
@@ -86,11 +90,11 @@ type Change struct {
 func (m *Manager) Apply(ctx context.Context, objects []*unstructured.Unstructured, ops ApplyOptions) ([]Change, error) {
 	ctx = logr.NewContext(ctx, logr.FromContextOrDiscard(ctx))
 
-	// Use this map to track changes made. Return it only once the changes have been made.
+	// Use this list to track changes made. Return it only once the changes have been made.
 	// Keyed by ObjMetadata (group/kind/namespace/name) to avoid lookup mismatches when
 	// the API server's dry-run response carries a different apiVersion than the input
 	// object — e.g., for CRs whose CRD has multiple versions or a conversion webhook.
-	changeMap := make(map[object.ObjMetadata]*Change)
+	changes := make([]Change, 0, len(objects))
 
 	inv, err := m.inventory(ctx)
 	if err != nil {
@@ -126,9 +130,10 @@ func (m *Manager) Apply(ctx context.Context, objects []*unstructured.Unstructure
 		var result *ssa.ChangeSet
 
 		result, err = m.resourceManager.ApplyAllStaged(ctx, objects, ssa.ApplyOptions{
-			Force:        ops.Force,
-			WaitInterval: ops.WaitInterval,
-			WaitTimeout:  ops.WaitTimeout,
+			Force:            ops.Force,
+			WaitInterval:     ops.WaitInterval,
+			WaitTimeout:      ops.WaitTimeout,
+			CustomStageKinds: ops.CustomStageKinds,
 		})
 
 		// only push new results to avoid "unchanged" results for objects that were already applied
@@ -167,10 +172,10 @@ func (m *Manager) Apply(ctx context.Context, objects []*unstructured.Unstructure
 				invErr = errors.Join(invErr, fmt.Errorf("resourceManager returned %q for unexpected object %s", e.Action, e.Subject))
 			}
 
-			change := &Change{ChangeSetEntry: ChangeSetEntry(e)}
+			change := Change{ChangeSetEntry: ChangeSetEntry(e)}
 			change.Diff = diff
 			change.Action = e.Action
-			changeMap[e.ObjMetadata] = change
+			changes = append(changes, change)
 
 			if !inventoryObjRefs.Contains(e.ObjMetadata) {
 				inventoryObjRefs = append(inventoryObjRefs, e.ObjMetadata)
@@ -188,11 +193,11 @@ func (m *Manager) Apply(ctx context.Context, objects []*unstructured.Unstructure
 	// return if there were inventory or apply errors and skip pruning
 	err = errors.Join(applyErr, invErr)
 	if err != nil {
-		return changesMapToArray(changeMap), err
+		return changes, err
 	}
 
 	if ops.NoPrune {
-		return changesMapToArray(changeMap), nil
+		return changes, nil
 	}
 
 	pruneObjRefs := calculatePruneObjects(inventoryObjRefs, objects)
@@ -233,14 +238,13 @@ func (m *Manager) Apply(ctx context.Context, objects []*unstructured.Unstructure
 			pruneErr = errors.Join(pruneErr, err)
 		}
 
-		change := changeFromObject(obj, diff, ssa.DeletedAction)
-		changeMap[change.ObjMetadata] = &change
+		changes = append(changes, changeFromObject(obj, diff, ssa.DeletedAction))
 	}
 
 	inv.Update(inventoryObjRefs)
 	invErr = inv.Write(ctx)
 
-	return changesMapToArray(changeMap), errors.Join(pruneErr, invErr)
+	return changes, errors.Join(pruneErr, invErr)
 }
 
 func invPolicyFailureErr(obj *unstructured.Unstructured, err error) error {
@@ -328,22 +332,6 @@ func changeFromObject(obj *unstructured.Unstructured, diff string, action Action
 		},
 		Diff: diff,
 	}
-}
-
-func changesMapToArray(changeMap map[object.ObjMetadata]*Change) []Change {
-	changes := []Change{}
-
-	for _, c := range changeMap {
-		// skip unknown actions as this state was used as a placeholder for actions not taken
-		// most likely these remain if an error was encountered half way through
-		if c.Action == ssa.UnknownAction {
-			continue
-		}
-
-		changes = append(changes, *c)
-	}
-
-	return changes
 }
 
 func containsCRDs(objects []*unstructured.Unstructured) bool {

--- a/kubernetes/ssa/internal/resourcemanager/mock.go
+++ b/kubernetes/ssa/internal/resourcemanager/mock.go
@@ -129,6 +129,8 @@ func (m *Mock) registerCRD(obj *unstructured.Unstructured) {
 	}
 }
 
+func (m *Mock) SetConcurrency(int) {}
+
 func (m *Mock) Get(ctx context.Context, meta object.ObjMetadata) (*unstructured.Unstructured, error) {
 	obj := m.objects[objKey{Group: meta.GroupKind.Group, Kind: meta.GroupKind.Kind, Namespace: meta.Namespace, Name: meta.Name}]
 	if obj == nil {

--- a/kubernetes/ssa/ssa.go
+++ b/kubernetes/ssa/ssa.go
@@ -67,6 +67,7 @@ type ResourceManager interface {
 		err error)
 	WaitForSetWithContext(ctx context.Context, set object.ObjMetadataSet, opts ssa.WaitOptions) error
 	Get(ctx context.Context, objMeta object.ObjMetadata) (*unstructured.Unstructured, error)
+	SetConcurrency(concurrency int)
 }
 
 // NewCustomManager creates a new manager with specified resource manager and inventory.
@@ -121,6 +122,11 @@ func NewManager(ctx context.Context, kubeconfig *rest.Config, fieldManagerName, 
 	}
 
 	return NewCustomManager(resourceManager, inventoryFactory, httpClient, mapper), nil
+}
+
+// SetConcurrency sets the concurrency level for apply operations in the resource manager.
+func (m *Manager) SetConcurrency(concurrency int) {
+	m.resourceManager.SetConcurrency(concurrency)
 }
 
 // Close performs any necessary cleanup, such as closing the HTTP connections.


### PR DESCRIPTION
tl;dr: don't use the map to store apply changes, aggregate them in a slice.

Also exposes two more configuration options (via underlying SSA library):

* concurrency to do dry-run apply concurrently
* custom stage options to promote some resource kinds to be applied before the rest (some kinds are promoted to earlier stages unconditionally)