### PR TITLE
chore(useragent):

### DIFF
--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -20,6 +20,10 @@ type Client struct {
 
 // NewForConfig initializes and returns a client using the provided config.
 func NewForConfig(config *rest.Config) (*Client, error) {
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
 	// rest.HTTPClientFor builds the *http.Client with TLS + auth configured,
 	// going through the transport cache normally (stable cache key).
 	httpClient, err := rest.HTTPClientFor(config)


### PR DESCRIPTION
## What? (description)

This is a proposal through a PR : 

In official kubernetes go library, the userAgent is set with running application default : 
https://github.com/kubernetes/client-go/blob/v0.36.2/kubernetes/clientset.go#L479-L481

In talos kubernetes client library, as it is never set and never goes through this default, the user agent is set to `net/http` go library default :   `Go-http-client/2.0`

Kubernetes sets a good-enough [default](https://github.com/kubernetes/client-go/blob/master/rest/config.go#L533-L540) that could be used for talos calls.

## Why? (reasoning)
This would allow a better auditing in kubernetes audit logs as we identified talos running some calls on nodes

## Acceptance

Please use the following checklist:

~~- [ ] you linked an issue (if applicable)~~
~~- [ ] you included tests (if applicable)~~
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
~~- [ ] you generated documentation (`make docs`)~~
- [x] you ran unit-tests (`make unit-tests`)

