### PR TITLE
chore(useragent): configure kubernetes http client user-agent instead of go net/http default

### DIFF
--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -20,6 +20,10 @@ type Client struct {
 
 // NewForConfig initializes and returns a client using the provided config.
 func NewForConfig(config *rest.Config) (*Client, error) {
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
 	// rest.HTTPClientFor builds the *http.Client with TLS + auth configured,
 	// going through the transport cache normally (stable cache key).
 	httpClient, err := rest.HTTPClientFor(config)


### PR DESCRIPTION
## What? (description)

This is a proposal through a PR, feel free to decline : 

In official kubernetes go library, the userAgent is set with running application default : 
https://github.com/kubernetes/client-go/blob/v0.36.2/kubernetes/clientset.go#L479-L481

In talos kubernetes client library, as it is never set and never goes through this default, the user agent is set to `net/http` go library default :   `Go-http-client/2.0`

Kubernetes sets a good-enough [default](https://github.com/kubernetes/client-go/blob/master/rest/config.go#L533-L540) that could be used for talos calls.

This would mainly help identifying talos calls in Kubernetes audit logging.

## Why? (reasoning)
This would allow a better auditing in kubernetes audit logs as we identified talos running some calls on nodes

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
~- [ ] you included tests (if applicable)~
- [x] you ran conformance (`make conformance`) -- But If I understand correctly, this will never pass properly as I'm not a talos member 
```
commit         Header Length                PASS          Header is 71 characters
commit         Imperative Mood              PASS          Commit begins with imperative verb
commit         Header Case                  PASS          Header case is valid
commit         Header Last Character        PASS          Header last character is valid
commit         DCO                          PASS          Developer Certificate of Origin was found
commit         GPG                          PASS          GPG signature found
commit         GPG Identity                 FAILED        EOF
commit         Conventional Commit          PASS          Commit message is a valid conventional commit
commit         Spellcheck                   PASS          Commit contains 0 misspellings
commit         Commit Body                  PASS          Commit body is valid
license        File Header                  PASS          All files have a valid license header
```
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
~~- [ ] you generated documentation (`make docs`)~~
- [x] you ran unit-tests (`make unit-tests`)

Closes siderolabs/go-kubernetes#65
