### PR TITLE
feat: add nodedrain package for client-side cordon and drain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/api v0.36.0
 	k8s.io/apimachinery v0.36.0
 	k8s.io/client-go v0.36.0
+	k8s.io/kubectl v0.36.0
 	sigs.k8s.io/controller-runtime v0.24.0
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -103,7 +104,6 @@ require (
 	k8s.io/component-base v0.36.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
-	k8s.io/kubectl v0.36.0 // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect

--- a/kubernetes/nodedrain/nodedrain.go
+++ b/kubernetes/nodedrain/nodedrain.go
@@ -1,0 +1,170 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package nodedrain provides reusable Kubernetes node cordon, drain, and uncordon operations for the
+// client side of a Talos upgrade or reboot.
+package nodedrain
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubectl/pkg/drain"
+
+	gokubernetes "github.com/siderolabs/go-kubernetes/kubernetes"
+)
+
+// DefaultDrainTimeout caps pod eviction when DrainOptions.Timeout is zero.
+const DefaultDrainTimeout = 5 * time.Minute
+
+// nodeReadyPollInterval is how often WaitForNodeReady polls.
+const nodeReadyPollInterval = 5 * time.Second
+
+// DrainOptions configures Drain. The zero value applies the canonical defaults: evict standalone pods,
+// honor each pod's own terminationGracePeriodSeconds, skip DaemonSet pods, allow emptyDir deletion, and
+// use DefaultDrainTimeout.
+type DrainOptions struct {
+	// Progress, if set, receives a human-readable message as each pod is evicted or deleted.
+	Progress func(string)
+	// Timeout caps pod eviction. Zero uses DefaultDrainTimeout.
+	Timeout time.Duration
+	// GracePeriodSeconds overrides the pod termination grace period. Zero (the default) maps to -1, which
+	// honors each pod's own terminationGracePeriodSeconds. A positive value overrides it. Values below -1
+	// are rejected.
+	GracePeriodSeconds int
+}
+
+// Cordon marks the node unschedulable. Idempotent: a no-op if the node is already cordoned.
+func Cordon(ctx context.Context, clientset kubernetes.Interface, nodeName string) error {
+	node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get node %q: %w", nodeName, err)
+	}
+
+	if err = drain.RunCordonOrUncordon(&drain.Helper{Ctx: ctx, Client: clientset}, node, true); err != nil {
+		return fmt.Errorf("failed to cordon node %q: %w", nodeName, err)
+	}
+
+	return nil
+}
+
+// Drain evicts the node's pods with the kubectl drain library: it honors each pod's grace period and
+// PodDisruptionBudgets, skips DaemonSet, mirror and static pods, and negotiates the eviction API version
+// (policy/v1, falling back to v1beta1 on older servers). The caller must cordon the node first.
+//
+// A drain that does not finish within the timeout returns an error; the caller decides whether that is
+// fatal or whether to proceed (e.g. to reboot anyway).
+func Drain(ctx context.Context, clientset kubernetes.Interface, nodeName string, opts DrainOptions) error {
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = DefaultDrainTimeout
+	}
+
+	if opts.GracePeriodSeconds < -1 {
+		return fmt.Errorf("invalid GracePeriodSeconds %d: must be -1, 0, or positive", opts.GracePeriodSeconds)
+	}
+
+	gracePeriod := opts.GracePeriodSeconds
+	if gracePeriod == 0 {
+		gracePeriod = -1
+	}
+
+	drainCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	helper := &drain.Helper{
+		Ctx:                 drainCtx,
+		Client:              clientset,
+		Force:               true,
+		GracePeriodSeconds:  gracePeriod,
+		IgnoreAllDaemonSets: true,
+		DeleteEmptyDirData:  true,
+		Timeout:             timeout,
+		Out:                 io.Discard,
+		ErrOut:              io.Discard,
+	}
+
+	if opts.Progress != nil {
+		helper.OnPodDeletionOrEvictionStarted = func(pod *corev1.Pod, usingEviction bool) {
+			verb := "deleting"
+			if usingEviction {
+				verb = "evicting"
+			}
+
+			opts.Progress(fmt.Sprintf("%s pod %s/%s", verb, pod.Namespace, pod.Name))
+		}
+
+		// Report each pod's outcome. The failure branch names the pod that could not be evicted, which is
+		// the diagnostic a caller needs when a PodDisruptionBudget stalls the drain.
+		helper.OnPodDeletionOrEvictionFinished = func(pod *corev1.Pod, usingEviction bool, err error) {
+			present, past := "delete", "deleted"
+			if usingEviction {
+				present, past = "evict", "evicted"
+			}
+
+			if err != nil {
+				opts.Progress(fmt.Sprintf("failed to %s pod %s/%s: %v", present, pod.Namespace, pod.Name, err))
+
+				return
+			}
+
+			opts.Progress(fmt.Sprintf("%s pod %s/%s", past, pod.Namespace, pod.Name))
+		}
+	}
+
+	if err := drain.RunNodeDrain(helper, nodeName); err != nil {
+		return fmt.Errorf("failed to drain node %q: %w", nodeName, err)
+	}
+
+	return nil
+}
+
+// Uncordon marks the node schedulable. A missing node is a no-op, so the call is safe to retry after a
+// node has been removed.
+func Uncordon(ctx context.Context, clientset kubernetes.Interface, nodeName string) error {
+	node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to get node %q: %w", nodeName, err)
+	}
+
+	if err = drain.RunCordonOrUncordon(&drain.Helper{Ctx: ctx, Client: clientset}, node, false); err != nil {
+		return fmt.Errorf("failed to uncordon node %q: %w", nodeName, err)
+	}
+
+	return nil
+}
+
+// WaitForNodeReady polls until the node reports Ready=True or the timeout elapses. Retryable failures
+// keep the poll going, anything else is returned at once.
+func WaitForNodeReady(ctx context.Context, clientset kubernetes.Interface, nodeName string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, nodeReadyPollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			if gokubernetes.IsRetryableError(err) {
+				return false, nil //nolint:nilerr
+			}
+
+			return false, fmt.Errorf("failed to get node %q: %w", nodeName, err)
+		}
+
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == corev1.NodeReady {
+				return cond.Status == corev1.ConditionTrue, nil
+			}
+		}
+
+		return false, nil
+	})
+}

--- a/kubernetes/nodedrain/nodedrain_test.go
+++ b/kubernetes/nodedrain/nodedrain_test.go
@@ -1,0 +1,220 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package nodedrain_test
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/siderolabs/go-kubernetes/kubernetes/nodedrain"
+)
+
+const testNode = "worker-1"
+
+func node(unschedulable bool) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: testNode},
+		Spec:       corev1.NodeSpec{Unschedulable: unschedulable},
+	}
+}
+
+func TestCordon(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clientset := fake.NewSimpleClientset(node(false))
+
+	require.NoError(t, nodedrain.Cordon(ctx, clientset, testNode))
+
+	got, err := clientset.CoreV1().Nodes().Get(ctx, testNode, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	assert.True(t, got.Spec.Unschedulable)
+}
+
+func TestUncordon(t *testing.T) {
+	t.Parallel()
+
+	t.Run("clears the unschedulable flag", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		clientset := fake.NewSimpleClientset(node(true))
+
+		require.NoError(t, nodedrain.Uncordon(ctx, clientset, testNode))
+
+		got, err := clientset.CoreV1().Nodes().Get(ctx, testNode, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		assert.False(t, got.Spec.Unschedulable)
+	})
+
+	t.Run("missing node is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		require.NoError(t, nodedrain.Uncordon(t.Context(), fake.NewSimpleClientset(), "ghost"))
+	})
+}
+
+// drainClientset builds a fake clientset whose discovery advertises the eviction subresource, so the
+// drain helper's eviction-support check passes and it actually exercises eviction.
+func drainClientset(objects ...runtime.Object) *fake.Clientset {
+	clientset := fake.NewSimpleClientset(objects...)
+	clientset.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Namespaced: true, Kind: "Pod"},
+				{Name: "pods/eviction", Namespaced: true, Kind: "Eviction", Group: "policy", Version: "v1"},
+			},
+		},
+	}
+
+	return clientset
+}
+
+func workloadPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "workload"},
+		Spec:       corev1.PodSpec{NodeName: testNode},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+}
+
+// progressRecorder collects progress messages from concurrent eviction callbacks.
+type progressRecorder struct {
+	messages []string
+	mu       sync.Mutex
+}
+
+func (p *progressRecorder) record(msg string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.messages = append(p.messages, msg)
+}
+
+func (p *progressRecorder) snapshot() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return slices.Clone(p.messages)
+}
+
+func TestDrain(t *testing.T) {
+	t.Parallel()
+
+	t.Run("evicts pods and reports each outcome", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		clientset := drainClientset(node(true), workloadPod())
+
+		// Emulate a successful eviction by deleting the pod, so the drain's wait-for-deletion completes.
+		clientset.PrependReactor("create", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+			if action.GetSubresource() != "eviction" {
+				return false, nil, nil
+			}
+
+			return true, nil, clientset.Tracker().Delete(corev1.SchemeGroupVersion.WithResource("pods"), "default", "workload")
+		})
+
+		var progress progressRecorder
+
+		require.NoError(t, nodedrain.Drain(ctx, clientset, testNode, nodedrain.DrainOptions{Progress: progress.record}))
+
+		messages := progress.snapshot()
+		assert.Contains(t, messages, "evicting pod default/workload")
+		assert.Contains(t, messages, "evicted pod default/workload")
+	})
+
+	// A refused eviction (what a PodDisruptionBudget causes) is surfaced through the returned error naming
+	// the pod, not the finished-callback: the kubectl drain helper invokes that callback only on the
+	// wait-for-termination path, while a failed eviction request returns directly.
+	t.Run("returns an error naming the pod a disruption budget blocks", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		clientset := drainClientset(node(true), workloadPod())
+
+		clientset.PrependReactor("create", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+			if action.GetSubresource() != "eviction" {
+				return false, nil, nil
+			}
+
+			return true, nil, errors.New("eviction refused by disruption budget")
+		})
+
+		err := nodedrain.Drain(ctx, clientset, testNode, nodedrain.DrainOptions{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "workload", "the error should name the pod that could not be evicted")
+	})
+
+	t.Run("rejects a grace period below -1", func(t *testing.T) {
+		t.Parallel()
+
+		err := nodedrain.Drain(t.Context(), drainClientset(node(true)), testNode, nodedrain.DrainOptions{GracePeriodSeconds: -2})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "GracePeriodSeconds")
+	})
+}
+
+func readyNode() *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: testNode},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+}
+
+func TestWaitForNodeReady(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns once the node reports Ready", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		clientset := fake.NewSimpleClientset(readyNode())
+
+		require.NoError(t, nodedrain.WaitForNodeReady(ctx, clientset, testNode, 30*time.Second))
+	})
+
+	// A Forbidden response will not resolve by waiting, so it must surface at once rather than stalling the
+	// caller until the timeout elapses.
+	t.Run("fails fast on a non-transient error", func(t *testing.T) {
+		t.Parallel()
+
+		clientset := fake.NewSimpleClientset()
+		clientset.PrependReactor("get", "nodes", func(ktesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewForbidden(corev1.Resource("nodes"), testNode, errors.New("forbidden"))
+		})
+
+		err := nodedrain.WaitForNodeReady(t.Context(), clientset, testNode, 30*time.Second)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsForbidden(err), "the Forbidden error should surface instead of a timeout")
+	})
+}


### PR DESCRIPTION
Wrap the kubectl drain library in a small package so callers can cordon, drain, uncordon, and wait for a node to become ready during a Talos upgrade or reboot.
